### PR TITLE
Test fixes

### DIFF
--- a/tests/test_vod_metadata.py
+++ b/tests/test_vod_metadata.py
@@ -348,7 +348,12 @@ class MediaInfoTests(unittest.TestCase):
         for section in self.D_reference.keys():
             for key, expected in self.D_reference[section].items():
                 actual = D[section][key]
-                self.assertEqual(actual, expected)
+                # Different MediaInfo versions give different strings for
+                # Format profile
+                if key == "Format profile":
+                    self.assertTrue(expected.startswith(actual))
+                else:
+                    self.assertEqual(actual, expected)
 
     @patch('vod_metadata.media_info.call_MediaInfo', autospec=True)
     def test_check_video(self, mock_call_MediaInfo):

--- a/tests/test_vod_metadata.py
+++ b/tests/test_vod_metadata.py
@@ -461,6 +461,28 @@ class VodMetadataTests(unittest.TestCase):
         vod_package.overwrite_xml()
         file_handle.write.assert_called_once_with(vod_package.write_xml())
 
+    def test_files_present(self):
+        vod_package = VodPackage(reference_xml)
+        self.assertFalse(vod_package.files_present())
+        vod_package.remove_poster()
+        vod_package.remove_preview()
+        vod_package.D_content["movie"] = reference_mp4
+        self.assertTrue(vod_package.files_present())
+
+    def test_make_update(self):
+        vod_package = VodPackage(reference_xml)
+        vod_package.make_update()
+        for ae_type in vod_package.D_ams:
+            self.assertEqual(vod_package.D_ams[ae_type]["Version_Major"], '2')
+        self.assertTrue(vod_package.is_update)
+
+    def test_make_delete(self):
+        vod_package = VodPackage(reference_xml)
+        vod_package.make_delete()
+        for ae_type in vod_package.D_ams:
+            self.assertEqual(vod_package.D_ams[ae_type]["Verb"], "DELETE")
+        self.assertTrue(vod_package.is_delete)
+
 
 # Reference values
 script_path = os.path.abspath(__file__)

--- a/vod_metadata/vodpackage.py
+++ b/vod_metadata/vodpackage.py
@@ -289,12 +289,10 @@ class VodPackage(object):
                 self.D_app[ae_type]["Codec"] = "MPEG2"
             elif commercial_name == "AVC":
                 avc_profile = format_profile[0]
-                avc_level = format_profile[format_profile.find("@"):].replace(
-                    ".", ""
-                )
-                self.D_app[ae_type]["Codec"] = "AVC {}P{}".format(
-                    avc_profile, avc_level
-                )
+                avc_level = format_profile.split('@')[1][1:]
+                avc_level = format(float(avc_level), '0.1f').replace('.', '')
+                codec = "AVC {}P@L{}".format(avc_profile, avc_level)
+                self.D_app[ae_type]["Codec"] = codec
             else:
                 raise InvalidMpeg("Could not determine codec for {}".format(
                     self.D_content[ae_type])


### PR DESCRIPTION
Fixes test failures with recent versions of MediaInfo; the `Format profile` string has changed. Also adds tests for the `file_present`, `make_update`, and `make_delete` methods.