### PR TITLE
3.6 dev test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6-dev"
+    - "pypy"
 
 before_install:
     - sudo apt-get update -qq

--- a/tests/test_vod_metadata.py
+++ b/tests/test_vod_metadata.py
@@ -217,14 +217,15 @@ class Md5CalcTests(unittest.TestCase):
 
 class MdGenTests(unittest.TestCase):
     @patch('vod_metadata.md_gen.random', autospec=True)
-    @patch('vod_metadata.md_gen.datetime.datetime', autospec=True)
-    def setUp(self, mock_datetime, mock_random):
+    def setUp(self, mock_random):
         self.temp_dir = mkdtemp()
         mock_random.randint.return_value = 1020
-        mock_datetime.today.return_value = datetime(1999, 9, 9, 1, 2)
+        timestamp = datetime(1999, 9, 9, 1, 2)
         vod_config = parse_config(find_data_file(default_config_path))
         self.vod_config = vod_config._replace(ecn_2009=True)
-        self.vod_package = generate_metadata(reference_mp4, self.vod_config)
+        self.vod_package = generate_metadata(
+            reference_mp4, self.vod_config, timestamp=timestamp
+        )
         self.ams_expected = {
             "Provider":  "001",
             "Product": "MOD",

--- a/vod_metadata/md_gen.py
+++ b/vod_metadata/md_gen.py
@@ -35,10 +35,10 @@ def _set_ae(vod_package, movie_name, ae_type, extensions):
 
 
 def generate_metadata(
-    file_path, vod_config, template_path=default_template_path
+    file_path, vod_config, template_path=default_template_path, timestamp=None
 ):
     # Time-sensitive values
-    timestamp = datetime.datetime.today()
+    timestamp = datetime.datetime.today() if timestamp is None else timestamp
     creation_date = timestamp.strftime("%Y-%m-%d")
     end_date = (timestamp + datetime.timedelta(days=999)).strftime("%Y-%m-%d")
     asset_id = timestamp.strftime("%Y%m%d%H%M")


### PR DESCRIPTION
This PR adds PyPy and the 3.6 development release to the automated Travis tests.

The test for the `md_gen` module failed on PyPy due to the mocking of `datetime.datetime`; I've replaced that with a default parameter (which gives a bit more flexibility in generating metadata as well).