### PR TITLE
Update Travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
+dist: xenial
 
 python:
     - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7-dev"
+    - "3.7"
     - "pypy"
     - "pypy3"
 
@@ -23,4 +24,4 @@ after_success:
     - coveralls
 
 notifications:
-    email: false
+    - email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
-    - "pypy"
-    - "pypy3"
+    - "pypy2.7-5.10.0"
+    - "pypy3.5"
 
 before_install:
     - sudo apt-get update -qq


### PR DESCRIPTION
This PR updates the Travis CI image to Xenial. This allows for testing on Python 3.7, though it makes the PyPy testing a little bit complicated.